### PR TITLE
Add Appbar to home and a little bit of refactoring of Appbar widget

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,13 +1,18 @@
 
 import 'package:flutter/material.dart';
+import 'package:dsc_app/widgets/app_bar.dart';
+
 
 class Home extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: CustomAppBar(title: 'DSC TIET'),
       body: SafeArea(
-        child: Container(),
-      ),
+        child: Container(
+          color: Colors.pinkAccent,
+        ),
+        ),
     );
   }
 }

--- a/lib/widgets/app_bar.dart
+++ b/lib/widgets/app_bar.dart
@@ -1,36 +1,49 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-class CustomAppBar extends StatelessWidget {
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final Size preferredSize;
+
+  CustomAppBar({@required this.title})
+      : preferredSize = Size.fromHeight(60.0);
+
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Image(
-              image: AssetImage('lib/assets/dsc_logo.png'),
-              height: MediaQuery.of(context).size.height * 0.0345394736830744,
+    return SafeArea(
+      child: Container(
+        child: Row(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 10.0),
+              child: Image(
+                image: AssetImage('lib/assets/dsc_logo.png'),
+                height: MediaQuery.of(context).size.height * 0.0345394736830744,
+              ),
             ),
-          ),
-          Align(
-            alignment: Alignment.centerRight,
-            child: Text(
-              'DSC TIET',
-              style: GoogleFonts.poppins(fontSize: 25),
+
+            Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                title,
+                style: GoogleFonts.poppins(fontSize: 25),
+              ),
             ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Image(
-              image: AssetImage('lib/assets/menu_icon.png'),
-              height: MediaQuery.of(context).size.height * 0.0345394736830744,
+
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 10.0),
+              child: Image(
+                image: AssetImage('lib/assets/menu_icon.png'),
+                height: MediaQuery.of(context).size.height * 0.0345394736830744,
+              ),
             ),
-          ),
-        ],
+
+          ],
+        ),
       ),
     );
+    }
   }
-}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:dsc_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(DscApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
![Image of home right now](https://user-images.githubusercontent.com/30950368/77239980-b3c72d80-6c06-11ea-9602-3c4863e8d8e9.jpeg)

ignore the bg color, that's just to show how much space app bar takes. 

The left logo will act as home button and the right logo will act as our burger menu. 

thinking about animating the right buttons such that the circles stack in a column to form bullet points for our pages.
